### PR TITLE
Put all references to UserProperties inside Try/Catch blocks

### DIFF
--- a/src/GAS/events.js
+++ b/src/GAS/events.js
@@ -32,7 +32,13 @@ function openSidebar() {
   var ssId = SpreadsheetApp.getActiveSpreadsheet().getId();
   PropertiesService.getDocumentProperties().setProperty(PROPERTY_SS_ID, ssId);
   MAILMAN_SESSION_ID = Utility.createGuid();
-  PropertiesService.getUserProperties().setProperty(MAILMAN_SESSION_ID_KEY, MAILMAN_SESSION_ID);
+  
+  try {
+    PropertiesService.getUserProperties().setProperty(MAILMAN_SESSION_ID_KEY, MAILMAN_SESSION_ID);
+  } catch (ex) {
+    // this can fail e.g. if the user hasn't granted this new scope yet.
+    // note a big deal, so eat the exception and continue.    
+  }
 
   logger.info("Opening sidebar for {SpreadsheetId}", ssId);
 

--- a/src/gas/logger.js
+++ b/src/gas/logger.js
@@ -36,7 +36,12 @@ function getLogger() {
     // try to get the current user 
     var userEmail =  Session.getActiveUser().getEmail();
     if (!userEmail) {
-      userEmail = PropertiesService.getUserProperties().getProperty("userEmail");
+      try {
+        userEmail = PropertiesService.getUserProperties().getProperty("userEmail");
+      } catch (ex1) {
+        // this can fail e.g. if the user hasn't granted this new scope yet.
+        // note a big deal, so eat the exception and continue.    
+      }
     }  
     if (!userEmail) {
       // the following "trick" is from https://stackoverflow.com/questions/12300777/determine-current-user-in-apps-script:
@@ -53,7 +58,13 @@ function getLogger() {
         userEmail = editors[0];
         // saving for better performance next run
         if (userEmail) {
-          PropertiesService.getUserProperties().setProperty("userEmail",userEmail);
+          try {
+            PropertiesService.getUserProperties().setProperty("userEmail",userEmail);
+          }
+          catch (ex2) {
+            // this can fail e.g. if the user hasn't granted this new scope yet.
+            // note a big deal, so eat the exception and continue.    
+          }
         }
       }
       catch (err) {
@@ -71,7 +82,13 @@ function getLogger() {
       .enrich(function() {
         if (!MAILMAN_SESSION_ID) {
           // this is normally set in events.openSidebar()
-          MAILMAN_SESSION_ID = PropertiesService.getUserProperties().getProperty(MAILMAN_SESSION_ID_KEY);
+          try {          
+            MAILMAN_SESSION_ID = PropertiesService.getUserProperties().getProperty(MAILMAN_SESSION_ID_KEY);
+          } catch (ex3) {
+            // this can fail e.g. if the user hasn't granted this new scope yet.
+            // note a big deal, so eat the exception and continue.    
+            MAILMAN_SESSION_ID = Utility.createGuid();
+          }
         }
         return {
           'Version': MAILMAN_VERSION,


### PR DESCRIPTION
Decided to go with the try/catch approach rather than taking all of there references out completely, as there is one instance that actually is useful: https://github.com/CityofEdmonton/Mailman/blob/7473f7e97adba5c053713af3371b1b233f129238/src/GAS/events.js#L33

This allows us to correlate events from different calls to the appscript.