### PR TITLE
Only escape double << not singles.

### DIFF
--- a/src/client/js/controllers/standard-mail-handler.js
+++ b/src/client/js/controllers/standard-mail-handler.js
@@ -135,7 +135,7 @@ var StandardMailHandler = function (parent, serviceFactory) {
 
     if (updateConfig.version === "1.0.0") {
       // one time fix for "upgrading" to rich text version
-      cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body.replace(/\</g, '&lt;').replace(/\>/g, '&gt;'));
+      cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body.replace(/\<\</g, '&lt;&lt;').replace(/\>\>/g, '&gt;&gt;'));
     } else {    
       cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body);
     }


### PR DESCRIPTION
Escaping single < or > was escaping actual html tags when users were using the Rich Text Mailman test version.

This fix only escapes actually double '<<' or '>>'.